### PR TITLE
chore: deprecate downloadFile and + legacy implementation

### DIFF
--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -133,6 +133,9 @@ const readFilePath = async () => {
 * [`stat(...)`](#stat)
 * [`rename(...)`](#rename)
 * [`copy(...)`](#copy)
+* [`downloadFile(...)`](#downloadfile)
+* [`addListener('progress', ...)`](#addlistenerprogress-)
+* [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 * [Enums](#enums)
@@ -400,6 +403,67 @@ Copy a file or directory
 --------------------
 
 
+### downloadFile(...)
+
+```typescript
+downloadFile(options: DownloadFileOptions) => Promise<DownloadFileResult>
+```
+
+Perform a http request to a server and download the file to the specified destination.
+
+This method has been deprecated since version 7.1.0.
+We recommend using the @capacitor/file-transfer plugin instead, in conjunction with this plugin.
+
+| Param         | Type                                                                |
+| ------------- | ------------------------------------------------------------------- |
+| **`options`** | <code><a href="#downloadfileoptions">DownloadFileOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#downloadfileresult">DownloadFileResult</a>&gt;</code>
+
+**Since:** 5.1.0
+
+--------------------
+
+
+### addListener('progress', ...)
+
+```typescript
+addListener(eventName: 'progress', listenerFunc: ProgressListener) => Promise<PluginListenerHandle>
+```
+
+Add a listener to file download progress events.
+
+This method has been deprecated since version 7.1.0.
+We recommend using the @capacitor/file-transfer plugin instead, in conjunction with this plugin.
+
+| Param              | Type                                                          |
+| ------------------ | ------------------------------------------------------------- |
+| **`eventName`**    | <code>'progress'</code>                                       |
+| **`listenerFunc`** | <code><a href="#progresslistener">ProgressListener</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 5.1.0
+
+--------------------
+
+
+### removeAllListeners()
+
+```typescript
+removeAllListeners() => Promise<void>
+```
+
+Remove all listeners for this plugin.
+
+This method has been deprecated since version 7.1.0.
+We recommend using the @capacitor/file-transfer plugin instead, in conjunction with this plugin.
+
+**Since:** 5.2.0
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -554,6 +618,40 @@ Copy a file or directory
 | **`uri`** | <code>string</code> | The uri where the file was copied into | 4.0.0 |
 
 
+#### DownloadFileResult
+
+| Prop       | Type                | Description                                                          | Since |
+| ---------- | ------------------- | -------------------------------------------------------------------- | ----- |
+| **`path`** | <code>string</code> | The path the file was downloaded to.                                 | 5.1.0 |
+| **`blob`** | <code>Blob</code>   | The blob data of the downloaded file. This is only available on web. | 5.1.0 |
+
+
+#### DownloadFileOptions
+
+| Prop            | Type                                            | Description                                                                                                                                                                                                                      | Default            | Since |
+| --------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`path`**      | <code>string</code>                             | The path the downloaded file should be moved to.                                                                                                                                                                                 |                    | 5.1.0 |
+| **`directory`** | <code><a href="#directory">Directory</a></code> | The directory to write the file to. If this option is used, filePath can be a relative path rather than absolute. The default is the `DATA` directory.                                                                           |                    | 5.1.0 |
+| **`progress`**  | <code>boolean</code>                            | An optional listener function to receive downloaded progress events. If this option is used, progress event should be dispatched on every chunk received. Chunks are throttled to every 100ms on Android/iOS to avoid slowdowns. |                    | 5.1.0 |
+| **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories.                                                                                                                                                                                | <code>false</code> | 5.1.2 |
+
+
+#### PluginListenerHandle
+
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
+#### ProgressStatus
+
+| Prop                | Type                | Description                                          | Since |
+| ------------------- | ------------------- | ---------------------------------------------------- | ----- |
+| **`url`**           | <code>string</code> | The url of the file being downloaded.                | 5.1.0 |
+| **`bytes`**         | <code>number</code> | The number of bytes downloaded so far.               | 5.1.0 |
+| **`contentLength`** | <code>number</code> | The total number of bytes to download for this file. | 5.1.0 |
+
+
 ### Type Aliases
 
 
@@ -582,6 +680,13 @@ Callback for receiving chunks read from a file, or error if something went wrong
 #### RenameOptions
 
 <code><a href="#copyoptions">CopyOptions</a></code>
+
+
+#### ProgressListener
+
+A listener function that receives progress events.
+
+<code>(progress: <a href="#progressstatus">ProgressStatus</a>): void</code>
 
 
 ### Enums

--- a/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/filesystem/LegacyFilesystemImplementation.kt
+++ b/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/filesystem/LegacyFilesystemImplementation.kt
@@ -1,0 +1,169 @@
+package com.capacitorjs.plugins.filesystem
+
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import android.os.Handler
+import android.os.Looper
+import com.getcapacitor.Bridge
+import com.getcapacitor.JSObject
+import com.getcapacitor.PluginCall
+import com.getcapacitor.plugin.util.HttpRequestHandler.HttpURLConnectionBuilder
+import com.getcapacitor.plugin.util.HttpRequestHandler.ProgressEmitter
+import org.json.JSONException
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.net.URISyntaxException
+import java.net.URL
+import kotlin.concurrent.thread
+
+class LegacyFilesystemImplementation internal constructor(private val context: Context) {
+    fun downloadFile(
+        call: PluginCall,
+        bridge: Bridge,
+        emitter: ProgressEmitter?,
+        callback: FilesystemDownloadCallback
+    ) {
+        val urlString = call.getString("url", "")
+        val handler = Handler(Looper.getMainLooper())
+
+        thread {
+            try {
+                val result =
+                    doDownloadInBackground(urlString, call, bridge, emitter)
+                handler.post { callback.onSuccess(result) }
+            } catch (error: Exception) {
+                handler.post { callback.onError(error) }
+            }
+        }
+    }
+
+    /**
+     * True if the given directory string is a public storage directory, which is accessible by the user or other apps.
+     * @param directory the directory string.
+     */
+    fun isPublicDirectory(directory: String?): Boolean {
+        return "DOCUMENTS" == directory || "EXTERNAL_STORAGE" == directory
+    }
+
+    private fun getDirectory(directory: String): File? {
+        val c = this.context
+        when (directory) {
+            "DOCUMENTS" -> return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+            "DATA", "LIBRARY" -> return c.filesDir
+            "CACHE" -> return c.cacheDir
+            "EXTERNAL" -> return c.getExternalFilesDir(null)
+            "EXTERNAL_STORAGE" -> return Environment.getExternalStorageDirectory()
+        }
+        return null
+    }
+
+    private fun getFileObject(path: String, directory: String?): File? {
+        if (directory == null) {
+            val u = Uri.parse(path)
+            if (u.scheme == null || u.scheme == "file") {
+                return File(u.path)
+            }
+        }
+
+        val androidDirectory = this.getDirectory(directory!!)
+
+        if (androidDirectory == null) {
+            return null
+        } else {
+            if (!androidDirectory.exists()) {
+                androidDirectory.mkdir()
+            }
+        }
+
+        return File(androidDirectory, path)
+    }
+
+    @Throws(IOException::class, URISyntaxException::class, JSONException::class)
+    private fun doDownloadInBackground(
+        urlString: String?,
+        call: PluginCall,
+        bridge: Bridge,
+        emitter: ProgressEmitter?
+    ): JSObject {
+        val headers = call.getObject("headers", JSObject())
+        val params = call.getObject("params", JSObject())
+        val connectTimeout = call.getInt("connectTimeout")
+        val readTimeout = call.getInt("readTimeout")
+        val disableRedirects = call.getBoolean("disableRedirects") ?: false
+        val shouldEncode = call.getBoolean("shouldEncodeUrlParams") ?: true
+        val progress = call.getBoolean("progress") ?: false
+
+        val method = call.getString("method")?.uppercase() ?: "GET"
+        val path = call.getString("path")!!
+        val directory = call.getString("directory", Environment.DIRECTORY_DOWNLOADS)
+
+        val url = URL(urlString)
+        val file = getFileObject(path, directory)
+
+        val connectionBuilder = HttpURLConnectionBuilder()
+            .setUrl(url)
+            .setMethod(method)
+            .setHeaders(headers)
+            .setUrlParams(params, shouldEncode)
+            .setConnectTimeout(connectTimeout)
+            .setReadTimeout(readTimeout)
+            .setDisableRedirects(disableRedirects)
+            .openConnection()
+
+        val connection = connectionBuilder.build()
+
+        connection.setSSLSocketFactory(bridge)
+
+        val connectionInputStream = connection.inputStream
+        val fileOutputStream = FileOutputStream(file, false)
+
+        val contentLength = connection.getHeaderField("content-length")
+        var bytes = 0
+        var maxBytes = 0
+
+        try {
+            maxBytes = contentLength?.toInt() ?: 0
+        } catch (ignored: NumberFormatException) {
+        }
+
+        val buffer = ByteArray(1024)
+        var len: Int
+
+        // Throttle emitter to 100ms so it doesn't slow down app
+        var lastEmitTime = System.currentTimeMillis()
+        val minEmitIntervalMillis: Long = 100
+
+        while ((connectionInputStream.read(buffer).also { len = it }) > 0) {
+            fileOutputStream.write(buffer, 0, len)
+
+            bytes += len
+
+            if (progress!! && null != emitter) {
+                val currentTime = System.currentTimeMillis()
+                if (currentTime - lastEmitTime > minEmitIntervalMillis) {
+                    emitter.emit(bytes, maxBytes)
+                    lastEmitTime = currentTime
+                }
+            }
+        }
+
+        if (progress!! && null != emitter) {
+            emitter.emit(bytes, maxBytes)
+        }
+
+        connectionInputStream.close()
+        fileOutputStream.close()
+
+        val ret = JSObject()
+        ret.put("path", file!!.absolutePath)
+        return ret
+    }
+
+    interface FilesystemDownloadCallback {
+        fun onSuccess(result: JSObject)
+
+        fun onError(error: Exception)
+    }
+}

--- a/packages/capacitor-plugin/ios/Sources/FilesystemPlugin/FilesystemPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/FilesystemPlugin/FilesystemPlugin.swift
@@ -30,6 +30,8 @@ public class FilesystemPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "downloadFile", returnType: CAPPluginReturnPromise)
     ]
 
+    private let legacyImplementation = LegacyFilesystemImplementation()
+
     private var fileService: FileService?
 
     override public func load() {
@@ -170,21 +172,25 @@ private extension FilesystemPlugin {
         }
     }
 
+    /**
+     * [DEPRECATED] Download a file
+     */
+    @available(*, deprecated, message: "Use @capacitor/file-transfer plugin instead.")
     @objc func downloadFile(_ call: CAPPluginCall) {
-        //        guard let url = call.getString("url") else { return call.reject("Must provide a URL") }
-        //        let progressEmitter: Filesystem.ProgressEmitter = { bytes, contentLength in
-        //            self.notifyListeners("progress", data: [
-        //                "url": url,
-        //                "bytes": bytes,
-        //                "contentLength": contentLength
-        //            ])
-        //        }
-        //
-        //        do {
-        //            try implementation.downloadFile(call: call, emitter: progressEmitter, config: bridge?.config)
-        //        } catch let error {
-        //            call.reject(error.localizedDescription)
-        //        }
+        guard let url = call.getString("url") else { return call.reject("Must provide a URL") }
+        let progressEmitter: LegacyFilesystemImplementation.ProgressEmitter = { bytes, contentLength in
+            self.notifyListeners("progress", data: [
+                "url": url,
+                "bytes": bytes,
+                "contentLength": contentLength
+            ])
+        }
+
+        do {
+            try legacyImplementation.downloadFile(call: call, emitter: progressEmitter, config: bridge?.config)
+        } catch let error {
+            call.reject(error.localizedDescription)
+        }
     }
 }
 

--- a/packages/capacitor-plugin/ios/Sources/FilesystemPlugin/LegacyFilesystemImplementation.swift
+++ b/packages/capacitor-plugin/ios/Sources/FilesystemPlugin/LegacyFilesystemImplementation.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Capacitor
+
+@objc public class LegacyFilesystemImplementation: NSObject {
+
+    public typealias ProgressEmitter = (_ bytes: Int64, _ contentLength: Int64) -> Void
+
+    // swiftlint:disable function_body_length
+    @objc public func downloadFile(call: CAPPluginCall, emitter: @escaping ProgressEmitter, config: InstanceConfiguration?) throws {
+        let directory = call.getString("directory", "DOCUMENTS")
+        guard let path = call.getString("path") else {
+            call.reject("Invalid file path")
+            return
+        }
+        guard var urlString = call.getString("url") else { throw URLError(.badURL) }
+
+        func handleDownload(downloadLocation: URL?, response: URLResponse?, error: Error?) {
+            if let error = error {
+                CAPLog.print("Error on download file", String(describing: downloadLocation), String(describing: response), String(describing: error))
+                call.reject(error.localizedDescription, "DOWNLOAD", error, nil)
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse {
+                if !(200...299).contains(httpResponse.statusCode) {
+                    CAPLog.print("Error downloading file:", urlString, httpResponse)
+                    call.reject("Error downloading file: \(urlString)", "DOWNLOAD")
+                    return
+                }
+                HttpRequestHandler.setCookiesFromResponse(httpResponse, config)
+            }
+
+            guard let location = downloadLocation else {
+                call.reject("Unable to get file after downloading")
+                return
+            }
+
+            let fileManager = FileManager.default
+
+            if let foundDir = getDirectory(directory: directory) {
+                let dir = fileManager.urls(for: foundDir, in: .userDomainMask).first
+
+                do {
+                    let dest = dir!.appendingPathComponent(path)
+                    CAPLog.print("Attempting to write to file destination: \(dest.absoluteString)")
+
+                    if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().absoluteString) {
+                        try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+                    }
+
+                    if FileManager.default.fileExists(atPath: dest.relativePath) {
+                        do {
+                            CAPLog.print("File already exists. Attempting to remove file before writing.")
+                            try fileManager.removeItem(at: dest)
+                        } catch let error {
+                            call.reject("Unable to remove existing file: \(error.localizedDescription)")
+                            return
+                        }
+                    }
+
+                    try fileManager.moveItem(at: location, to: dest)
+                    CAPLog.print("Downloaded file successfully! \(dest.absoluteString)")
+                    call.resolve(["path": dest.absoluteString])
+                } catch let error {
+                    call.reject("Unable to download file: \(error.localizedDescription)", "DOWNLOAD", error)
+                    return
+                }
+            } else {
+                call.reject("Unable to download file. Couldn't find directory \(directory)")
+            }
+        }
+
+        let method = call.getString("method", "GET")
+
+        let headers = (call.getObject("headers") ?? [:]) as [String: Any]
+        let params = (call.getObject("params") ?? [:]) as [String: Any]
+        let responseType = call.getString("responseType", "text")
+        let connectTimeout = call.getDouble("connectTimeout")
+        let readTimeout = call.getDouble("readTimeout")
+
+        if urlString == urlString.removingPercentEncoding {
+            guard let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)  else { throw URLError(.badURL) }
+            urlString = encodedUrlString
+        }
+
+        let progress = call.getBool("progress", false)
+
+        let request = try HttpRequestHandler.CapacitorHttpRequestBuilder()
+            .setUrl(urlString)
+            .setMethod(method)
+            .setUrlParams(params)
+            .openConnection()
+            .build()
+
+        request.setRequestHeaders(headers)
+
+        // Timeouts in iOS are in seconds. So read the value in millis and divide by 1000
+        let timeout = (connectTimeout ?? readTimeout ?? 600000.0) / 1000.0
+        request.setTimeout(timeout)
+
+        if let data = call.options["data"] as? JSValue {
+            do {
+                try request.setRequestBody(data)
+            } catch {
+                // Explicitly reject if the http request body was not set successfully,
+                // so as to not send a known malformed request, and to provide the developer with additional context.
+                call.reject(error.localizedDescription, (error as NSError).domain, error, nil)
+                return
+            }
+        }
+
+        var session: URLSession!
+        var task: URLSessionDownloadTask!
+        let urlRequest = request.getUrlRequest()
+
+        if progress {
+            class ProgressDelegate: NSObject, URLSessionDataDelegate, URLSessionDownloadDelegate {
+                private var handler: (URL?, URLResponse?, Error?) -> Void
+                private var downloadLocation: URL?
+                private var response: URLResponse?
+                private var emitter: (Int64, Int64) -> Void
+                private var lastEmitTimestamp: TimeInterval = 0.0
+
+                init(downloadHandler: @escaping (URL?, URLResponse?, Error?) -> Void, progressEmitter: @escaping (Int64, Int64) -> Void) {
+                    handler = downloadHandler
+                    emitter = progressEmitter
+                }
+
+                func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+                    let currentTimestamp = Date().timeIntervalSince1970
+                    let timeElapsed = currentTimestamp - lastEmitTimestamp
+
+                    if totalBytesExpectedToWrite > 0 {
+                        if timeElapsed >= 0.1 {
+                            emitter(totalBytesWritten, totalBytesExpectedToWrite)
+                            lastEmitTimestamp = currentTimestamp
+                        }
+                    } else {
+                        emitter(totalBytesWritten, 0)
+                        lastEmitTimestamp = currentTimestamp
+                    }
+                }
+
+                func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+                    downloadLocation = location
+                    handler(downloadLocation, downloadTask.response, downloadTask.error)
+                }
+
+                func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+                    if error != nil {
+                        handler(downloadLocation, task.response, error)
+                    }
+                }
+            }
+
+            let progressDelegate = ProgressDelegate(downloadHandler: handleDownload, progressEmitter: emitter)
+            session = URLSession(configuration: .default, delegate: progressDelegate, delegateQueue: nil)
+            task = session.downloadTask(with: urlRequest)
+        } else {
+            task = URLSession.shared.downloadTask(with: urlRequest, completionHandler: handleDownload)
+        }
+
+        task.resume()
+    }
+    // swiftlint:enable function_body_length
+
+    /**
+     * Get the SearchPathDirectory corresponding to the JS string
+     */
+    private func getDirectory(directory: String?) -> FileManager.SearchPathDirectory? {
+        if let directory = directory {
+            switch directory {
+            case "CACHE":
+                return .cachesDirectory
+            case "LIBRARY":
+                return .libraryDirectory
+            default:
+                return .documentDirectory
+            }
+        }
+        return nil
+    }
+}

--- a/packages/capacitor-plugin/src/definitions.ts
+++ b/packages/capacitor-plugin/src/definitions.ts
@@ -1,4 +1,4 @@
-import type { PermissionState } from '@capacitor/core';
+import type { HttpOptions, PermissionState, PluginListenerHandle } from '@capacitor/core';
 
 export type CallbackID = string;
 
@@ -479,12 +479,88 @@ export interface CopyResult {
   uri: string;
 }
 
+export interface DownloadFileOptions extends HttpOptions {
+  /**
+   * The path the downloaded file should be moved to.
+   *
+   * @since 5.1.0
+   */
+  path: string;
+  /**
+   * The directory to write the file to.
+   * If this option is used, filePath can be a relative path rather than absolute.
+   * The default is the `DATA` directory.
+   *
+   * @since 5.1.0
+   */
+  directory?: Directory;
+  /**
+   * An optional listener function to receive downloaded progress events.
+   * If this option is used, progress event should be dispatched on every chunk received.
+   * Chunks are throttled to every 100ms on Android/iOS to avoid slowdowns.
+   *
+   * @since 5.1.0
+   */
+  progress?: boolean;
+  /**
+   * Whether to create any missing parent directories.
+   *
+   * @default false
+   * @since 5.1.2
+   */
+  recursive?: boolean;
+}
+
+export interface DownloadFileResult {
+  /**
+   * The path the file was downloaded to.
+   *
+   * @since 5.1.0
+   */
+  path?: string;
+  /**
+   * The blob data of the downloaded file.
+   * This is only available on web.
+   *
+   * @since 5.1.0
+   */
+  blob?: Blob;
+}
+
+export interface ProgressStatus {
+  /**
+   * The url of the file being downloaded.
+   *
+   * @since 5.1.0
+   */
+  url: string;
+  /**
+   * The number of bytes downloaded so far.
+   *
+   * @since 5.1.0
+   */
+  bytes: number;
+  /**
+   * The total number of bytes to download for this file.
+   *
+   * @since 5.1.0
+   */
+  contentLength: number;
+}
+
 /**
  * Callback for receiving chunks read from a file, or error if something went wrong.
  *
  * @since 7.1.0
  */
 export type ReadFileInChunksCallback = (chunkRead: ReadFileResult | null, err?: any) => void;
+
+/**
+ * A listener function that receives progress events.
+ *
+ * @since 5.1.0
+ */
+export type ProgressListener = (progress: ProgressStatus) => void;
 
 export interface FilesystemPlugin {
   /**
@@ -591,6 +667,39 @@ export interface FilesystemPlugin {
    * @since 1.0.0
    */
   copy(options: CopyOptions): Promise<CopyResult>;
+
+  /**
+   * Perform a http request to a server and download the file to the specified destination.
+   *
+   * This method has been deprecated since version 7.1.0.
+   * We recommend using the @capacitor/file-transfer plugin instead, in conjunction with this plugin.
+   *
+   * @since 5.1.0
+   * @deprecated Use the @capacitor/file-transfer plugin instead.
+   */
+  downloadFile(options: DownloadFileOptions): Promise<DownloadFileResult>;
+
+  /**
+   * Add a listener to file download progress events.
+   *
+   * This method has been deprecated since version 7.1.0.
+   * We recommend using the @capacitor/file-transfer plugin instead, in conjunction with this plugin.
+   *
+   * @since 5.1.0
+   * @deprecated Use the @capacitor/file-transfer plugin instead.
+   */
+  addListener(eventName: 'progress', listenerFunc: ProgressListener): Promise<PluginListenerHandle>;
+
+  /**
+   * Remove all listeners for this plugin.
+   *
+   * This method has been deprecated since version 7.1.0.
+   * We recommend using the @capacitor/file-transfer plugin instead, in conjunction with this plugin.
+   *
+   * @since 5.2.0
+   * @deprecated Use the @capacitor/file-transfer plugin instead.
+   */
+  removeAllListeners(): Promise<void>;
 }
 
 /**

--- a/packages/capacitor-plugin/src/web.ts
+++ b/packages/capacitor-plugin/src/web.ts
@@ -1,4 +1,4 @@
-import { WebPlugin } from '@capacitor/core';
+import { WebPlugin, buildRequestInit } from '@capacitor/core';
 
 import type {
   AppendFileOptions,
@@ -23,6 +23,9 @@ import type {
   Directory,
   ReadFileInChunksOptions,
   CallbackID,
+  DownloadFileOptions,
+  DownloadFileResult,
+  ProgressStatus,
   ReadFileInChunksCallback,
 } from './definitions';
 import { Encoding } from './definitions';
@@ -617,6 +620,68 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       uri: toPath,
     };
   }
+
+  /**
+   * Function that performs a http request to a server and downloads the file to the specified destination
+   *
+   * @deprecated Use the @capacitor/file-transfer plugin instead.
+   * @param options the options for the download operation
+   * @returns a promise that resolves with the download file result
+   */
+  public downloadFile = async (options: DownloadFileOptions): Promise<DownloadFileResult> => {
+    const requestInit = buildRequestInit(options, options.webFetchExtra);
+    const response = await fetch(options.url, requestInit);
+    let blob: Blob;
+
+    if (!options.progress) blob = await response.blob();
+    else if (!response?.body) blob = new Blob();
+    else {
+      const reader = response.body.getReader();
+
+      let bytes = 0;
+      const chunks: (Uint8Array | undefined)[] = [];
+
+      const contentType: string | null = response.headers.get('content-type');
+      const contentLength: number = parseInt(response.headers.get('content-length') || '0', 10);
+
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) break;
+
+        chunks.push(value);
+        bytes += value?.length || 0;
+
+        const status: ProgressStatus = {
+          url: options.url,
+          bytes,
+          contentLength,
+        };
+
+        this.notifyListeners('progress', status);
+      }
+
+      const allChunks = new Uint8Array(bytes);
+      let position = 0;
+      for (const chunk of chunks) {
+        if (typeof chunk === 'undefined') continue;
+
+        allChunks.set(chunk, position);
+        position += chunk.length;
+      }
+
+      blob = new Blob([allChunks.buffer], { type: contentType || undefined });
+    }
+
+    const result = await this.writeFile({
+      path: options.path,
+      directory: options.directory ?? undefined,
+      recursive: options.recursive ?? false,
+      data: blob,
+    });
+
+    return { path: result.uri, blob };
+  };
 
   private isBase64String(str: string): boolean {
     try {

--- a/packages/example-app-capacitor/src/js/capacitor-welcome.js
+++ b/packages/example-app-capacitor/src/js/capacitor-welcome.js
@@ -109,6 +109,11 @@ window.customElements.define(
         <button id="renameFileTestUrl" class="button">renameFileTestUrl</button>
         <br><br>
         <button id="copyFileTestUrl" class="button">copyFileTestUrl</button>
+        <br><br>
+        <button id="downloadSmallFile" class="button">deprecated downloadFile (small)</button>
+        <br><br>
+        <button id="downloadLargeFile" class="button">deprecated downloadFile (large)</button>
+        <br><br>
         <br><br><br><br><br><br>
       </main>
     </div>
@@ -429,6 +434,37 @@ window.customElements.define(
         await rmdirAll('da');
         console.log('copy finished');
       });
+      self.shadowRoot.querySelector("#downloadSmallFile").addEventListener('click', async function (e) {
+        download('https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/examples/learning/helloworld.pdf');
+      });
+      self.shadowRoot.querySelector("#downloadLargeFile").addEventListener('click', async function (e) {
+        download('https://raw.githubusercontent.com/kyokidG/large-pdf-viewer-poc/58a3df6adc4fe9bd5f02d2f583d6747e187d93ae/public/test2.pdf');
+      });
+
+      // download a file from the provided url
+      async function download(file) {
+        try {
+          const fileUrlSplit = file.split('/');
+          const path = fileUrlSplit[fileUrlSplit.length - 1];
+    
+          Filesystem.addListener('progress', (status) => {
+            const progress = status.bytes / status.contentLength;
+            console.log("Download progress -> " + progress);
+          });
+    
+          const downloadFileResult = await Filesystem.downloadFile({
+            url: file,
+            directory: Directory.Cache,
+            path,
+            progress: true,
+          });
+    
+          console.log('Downloaded file!', downloadFileResult);
+          alert('Downloaded file successfully!');
+        } catch (err) {
+          console.error('Unable to download file', err);
+        }
+      };
 
       // Helper function to run the provided promise-returning function on a single item or array of items
       async function doAll(item, callback) {


### PR DESCRIPTION
This PR adds the missing methods that are in the current `@capacitor/filesystem` plugin, but marks them as deprecated, with recommendation to use the upcoming `@capacitor/file-transfer` plugin in conjunction with this one.

The implementation was ported from the 7.0.0 version of the plugin and was left the same, apart from converting the Java code to Kotlin on Android.

The example app was also updated to test the method (check web console logs for info).