### PR TITLE
fix: use default is directory is empty string

### DIFF
--- a/packages/capacitor-plugin/ios/Sources/FilesystemPlugin/CAPPluginCall+Accelerators.swift
+++ b/packages/capacitor-plugin/ios/Sources/FilesystemPlugin/CAPPluginCall+Accelerators.swift
@@ -60,7 +60,7 @@ extension CAPPluginCall {
     private func getSearchPath(
         _ key: String, withDefaultSearchPath defaultSearchPath: IONFILESearchPath, andDefaultDirectoryType defaultDirectoryType: IONFILEDirectoryType? = nil
     ) -> IONFILESearchPath {
-        guard let directoryParameter = getString(key) else {
+        guard let directoryParameter = getString(key), directoryParameter.isEmpty == false else {
             return defaultSearchPath
         }
 


### PR DESCRIPTION
An issue was happening where if you provided the directory attribute, but it is empty, it was defaulting to the documents directory. We should only use the default directory if an actual directory is provided, otherwise, an issue could happen where we provide the full URI in `path` and `directory: ""`, and that could result in a duplicate URI path, causing methods to fail.

Therefore we added an additional fix to check if directory attribute is empty.