### PR TITLE
fix(ios): use from instead of exact for Capacitor dependency

### DIFF
--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["FilesystemPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "7.1.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor-filesystem/issues/13