### PR TITLE
fix(ios): fix SPM package name not matching CLI CapApp-SPM generated name

### DIFF
--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -2,11 +2,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "FilesystemCapacitor",
+    name: "CapacitorFilesystem",
     platforms: [.iOS(.v14)],
     products: [
         .library(
-            name: "FilesystemCapacitor",
+            name: "CapacitorFilesystem",
             targets: ["FilesystemPlugin"])
     ],
     dependencies: [

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "xcodebuild -scheme FilesystemCapacitor -destination generic/platform=iOS",
+    "verify:ios": "xcodebuild -scheme CapacitorFilesystem -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",


### PR DESCRIPTION
This change updates the SPM package name to match what the capacitor CLI generates for the `CapApp-SPM` package.

I'm not completely sure why the name was transposed when moved into this repository (original [Package.swift](https://github.com/ionic-team/capacitor-plugins/blob/main/filesystem/Package.swift)), but my xcode project was failing to resolve the CapApp-SPM dependency (even after patching in https://github.com/ionic-team/capacitor-filesystem/pull/14), and eventually I edited the `CapApp-SPM/Package.swift` to depend on the product `FilesystemCapacitor` from the package `CapacitorFilesystem` (despite the warnings not to edit the file), and I was able to finally resolve all the dependencies.

This change will remove the need for manually editing the `CapApp-SPM/Package.swift` because the product will match the package name that the CLI uses.