### PR TITLE
fix(ios): Simplify SPM usage for native library

### DIFF
--- a/.github/actions/prepare-example-app/action.yml
+++ b/.github/actions/prepare-example-app/action.yml
@@ -1,0 +1,18 @@
+name: 'Prepare Example app'
+description: 'Does necessary pre-work for the example app to compile natively'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Build plugin'
+      working-directory: ./packages/capacitor-plugin
+      run: npm run build
+    - name: 'Install example app dependencies'
+      working-directory: ./packages/example-app-capacitor
+      run: npm i
+    - name: 'Build Web example app'
+      working-directory: ./packages/example-app-capacitor
+      run: npm run build
+    - name: 'Sync example app native platforms'
+      working-directory: ./packages/example-app-capacitor
+      run: npx cap sync

--- a/.github/actions/prepare-example-app/action.yml
+++ b/.github/actions/prepare-example-app/action.yml
@@ -6,13 +6,17 @@ runs:
   steps:
     - name: 'Build plugin'
       working-directory: ./packages/capacitor-plugin
+      shell: bash
       run: npm run build
     - name: 'Install example app dependencies'
       working-directory: ./packages/example-app-capacitor
+      shell: bash
       run: npm i
     - name: 'Build Web example app'
       working-directory: ./packages/example-app-capacitor
+      shell: bash
       run: npm run build
     - name: 'Sync example app native platforms'
       working-directory: ./packages/example-app-capacitor
+      shell: bash
       run: npx cap sync

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,7 +16,7 @@ jobs:
     needs: 'setup'
     uses: ./.github/workflows/reusable_build.yml
 
-  verify-plugin:
+  verify-plugin-android:
     needs: ['setup', 'lint', 'build']
     runs-on: 'macos-15'
     timeout-minutes: 30
@@ -24,33 +24,46 @@ jobs:
       - uses: actions/checkout@v4
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
-      - name: 'Verify iOS + Android + Web'
+      - name: 'Verify Android'
         working-directory: ./packages/capacitor-plugin
-        run: npm run verify
+        run: npm run verify:android
 
-  build-example-app:
-    needs: ['verify-plugin']
+  verify-plugin-ios:
+    needs: ['setup', 'lint', 'build']
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
-      - name: 'Build plugin'
+      - name: 'Verify iOS'
         working-directory: ./packages/capacitor-plugin
-        run: npm run build
-      - name: 'Install example app dependencies'
-        working-directory: ./packages/example-app-capacitor
-        run: npm i
-      - name: 'Build Web example app'
-        working-directory: ./packages/example-app-capacitor
-        run: npm run build
-      - name: 'Sync example app native platforms'
-        working-directory: ./packages/example-app-capacitor
-        run: npx cap sync
+        run: npm run verify:ios
+
+  build-example-app-android:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
       - name: 'Build Android example app'
         working-directory: ./packages/example-app-capacitor/android
         run: ./gradlew clean assembleDebug
+    
+  build-example-app-ios:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
       - name: 'Build iOS example app'
         working-directory: ./packages/example-app-capacitor/ios/App
         run: xcodebuild clean build -workspace App.xcworkspace -scheme App CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -27,6 +27,11 @@ jobs:
       - name: 'Verify Android'
         working-directory: ./packages/capacitor-plugin
         run: npm run verify:android
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
+      - name: 'Build Android example app'
+        working-directory: ./packages/example-app-capacitor/android
+        run: ./gradlew clean assembleDebug
 
   verify-plugin-ios:
     needs: ['setup', 'lint', 'build']
@@ -39,29 +44,6 @@ jobs:
       - name: 'Verify iOS'
         working-directory: ./packages/capacitor-plugin
         run: npm run verify:ios
-
-  build-example-app-android:
-    needs: ['verify-plugin-ios', 'verify-plugin-android']
-    runs-on: 'macos-15'
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Setup Tools'
-        uses: ./.github/actions/setup-tools
-      - name: 'Prepare example app'
-        uses: ./.github/actions/prepare-example-app
-      - name: 'Build Android example app'
-        working-directory: ./packages/example-app-capacitor/android
-        run: ./gradlew clean assembleDebug
-    
-  build-example-app-ios:
-    needs: ['verify-plugin-ios', 'verify-plugin-android']
-    runs-on: 'macos-15'
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Setup Tools'
-        uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'
         uses: ./.github/actions/prepare-example-app
       - name: 'Build iOS example app'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -27,11 +27,6 @@ jobs:
       - name: 'Verify Android'
         working-directory: ./packages/capacitor-plugin
         run: npm run verify:android
-      - name: 'Prepare example app'
-        uses: ./.github/actions/prepare-example-app
-      - name: 'Build Android example app'
-        working-directory: ./packages/example-app-capacitor/android
-        run: ./gradlew clean assembleDebug
 
   verify-plugin-ios:
     needs: ['setup', 'lint', 'build']
@@ -44,6 +39,29 @@ jobs:
       - name: 'Verify iOS'
         working-directory: ./packages/capacitor-plugin
         run: npm run verify:ios
+
+  build-example-app-android:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
+      - name: 'Build Android example app'
+        working-directory: ./packages/example-app-capacitor/android
+        run: ./gradlew clean assembleDebug
+    
+  build-example-app-ios:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'
         uses: ./.github/actions/prepare-example-app
       - name: 'Build iOS example app'

--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -10,20 +10,16 @@ let package = Package(
             targets: ["FilesystemPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
+        .package(url: "https://github.com/ionic-team/ion-ios-filesystem.git", from: "1.0.1")
     ],
     targets: [
-        .binaryTarget(
-            name: "IONFilesystemLib",
-            url: "https://github.com/ionic-team/ion-ios-filesystem/releases/download/1.0.1/IONFilesystemLib.zip",
-            checksum: "2d333c2be44a51f804f3b592d61fa19d582afc40b6916c1c9d1dee43c30657b9" // sha-256
-        ),
         .target(
             name: "FilesystemPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                "IONFilesystemLib"
+                .product(name: "IONFilesystemLib", package: "ion-ios-filesystem")
             ],
             path: "ios/Sources/FilesystemPlugin"),
         .testTarget(


### PR DESCRIPTION
This PR updates the SPM declaration of the iOS filesystem native library to be retrieved from GitHub directly instead of relying on a binary target.