### PR TITLE
fix(filesystem): make readdir ordering deterministic across iOS and Android

### DIFF
--- a/android/src/main/kotlin/com/capacitorjs/plugins/filesystem/FilesystemMethodResults.kt
+++ b/android/src/main/kotlin/com/capacitorjs/plugins/filesystem/FilesystemMethodResults.kt
@@ -38,7 +38,14 @@ fun createWriteResultObject(uri: Uri, mode: IONFILESaveMode): JSObject? =
  * @return a result [JSObject] for the list of a directories contents
  */
 fun createReadDirResultObject(list: List<IONFILEMetadataResult>): JSObject = JSObject().also {
-    it.put(OUTPUT_FILES, JSArray(list.map { child -> child.toResultObject() }))
+    val sorted = list.sortedWith(
+        compareBy<IONFILEMetadataResult>(
+            { it.lastModifiedTimestamp },
+            { it.createdTimestamp },
+            { it.name.lowercase() },
+        ),
+    )
+    it.put(OUTPUT_FILES, JSArray(sorted.map { child -> child.toResultObject() }))
 }
 
 /**

--- a/ios/Sources/FilesystemPlugin/FilesystemOperationExecutor.swift
+++ b/ios/Sources/FilesystemPlugin/FilesystemOperationExecutor.swift
@@ -35,7 +35,19 @@ class FilesystemOperationExecutor {
                 try service.removeDirectory(atURL: url, includeIntermediateDirectories: recursive)
             case .readdir(let url):
                 let directoryAttributes = try service.listDirectory(atURL: url)
-                    .map { try fetchItemAttributesJSObject(using: service, atURL: $0) }
+                    .map { childUrl in
+                        (url: childUrl, attributes: try service.getItemAttributes(atURL: childUrl))
+                    }
+                    .sorted { lhs, rhs in
+                        if lhs.attributes.modificationDateTimestamp != rhs.attributes.modificationDateTimestamp {
+                            return lhs.attributes.modificationDateTimestamp < rhs.attributes.modificationDateTimestamp
+                        }
+                        if lhs.attributes.creationDateTimestamp != rhs.attributes.creationDateTimestamp {
+                            return lhs.attributes.creationDateTimestamp < rhs.attributes.creationDateTimestamp
+                        }
+                        return lhs.url.lastPathComponent.localizedCaseInsensitiveCompare(rhs.url.lastPathComponent) == .orderedAscending
+                    }
+                    .map { $0.attributes.toJSResult(with: $0.url) }
                 resultData = [Constants.ResultDataKey.files: directoryAttributes]
             case .stat(let url):
                 resultData = try fetchItemAttributesJSObject(using: service, atURL: url)


### PR DESCRIPTION
Closes #74

## Summary
- make `readdir` results deterministic on Android by sorting entries by `mtime`, then `ctime`, then case-insensitive `name`
- apply the same ordering strategy on iOS so both platforms return the same chronological ordering semantics
- keep API shape unchanged while eliminating platform-dependent native directory iteration order

## Test plan
- [ ] create files with distinct modification times in the same folder and call `Filesystem.readdir` on Android
- [ ] run the same scenario on iOS and verify identical ordering
- [ ] verify tie-breakers by creating files with same `mtime` and checking `ctime`, then `name` ordering
- [ ] ensure returned fields (`name`, `type`, `size`, `mtime`, `ctime`, `uri`) are unchanged