### PR TITLE
chore(ci): use Xcode 26

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -15,3 +15,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: npm i
+    - name: Set Xcode 26.0  # minimum support Xcode version by Capacitor 8
+      if: runner.os == 'macOS'
+      shell: bash
+      run: sudo xcode-select --switch /Applications/Xcode_26.0.app


### PR DESCRIPTION
Clone of https://github.com/ionic-team/capacitor-barcode-scanner/pull/120

Note that the publish cocoapods workflow does not use the reusable action that is changed in this PR, but it already sets Xcode 26 currently.