### PR TITLE
chore(ci): Check every maven central version for android publish

### DIFF
--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -17,9 +17,8 @@ publish_plugin_android () {
             # Get latest plugin info from MavenCentral
             PLUGIN_PUBLISHED_URL="https://repo1.maven.org/maven2/com/capacitorjs/$PLUGIN_NAME/maven-metadata.xml"
             PLUGIN_PUBLISHED_DATA=$(curl -s $PLUGIN_PUBLISHED_URL)
-            PLUGIN_PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $PLUGIN_PUBLISHED_DATA)"
 
-            if [[ $PLUGIN_VERSION == $PLUGIN_PUBLISHED_VERSION ]]; then
+            if echo "$PLUGIN_PUBLISHED_DATA" | grep -q "<version>$PLUGIN_VERSION</version>"; then
                 printf %"s\n\n" "Duplicate: a published plugin $PLUGIN_NAME exists for version $PLUGIN_VERSION, skipping..."
             else
                 # Make log dir if doesnt exist


### PR DESCRIPTION
## Description

Check for all versions published to Maven Central, instead of just the latest one.

This is a copy of https://github.com/ionic-team/capacitor-plugins/pull/2512, applied to this repository.

## Rationale

In a situation where `package.json` version is older than the latest version on Maven Central (can happen if we trigger native android publish from a maintenance branch, or for plugins that have migrated from another repository), the publishing script was assuming that the version needed to be published, and would often fail because said version would already exist in Maven Central.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [x] Other

---
> Generated with [Claude Code](https://claude.ai/code)